### PR TITLE
feat: for mobile haompage ui

### DIFF
--- a/src/components/HomePage/styles.js
+++ b/src/components/HomePage/styles.js
@@ -57,8 +57,8 @@ export const S = {
       background-position: center;
       background-size: cover;
       background-repeat: no-repeat;
-      width: 85px;
-      height: 210px;
+      width: 100%;
+      height: 100%;
     }
 
     &:hover {

--- a/src/components/HomePageM/index.jsx
+++ b/src/components/HomePageM/index.jsx
@@ -1,27 +1,20 @@
-import { S } from './styles'
 import { useTranslation } from 'react-i18next'
-// import data from '../../assets/data'
+import { S } from './styles'
 
-export default function HomePage() {
+export default function HomePageM() {
   const { t } = useTranslation()
-  /** TODO:
-   *    For link logic.
-   *    尚未開始所以先註解掉。
-   */
-  //   const gamePages = Object.keys(data).map(e => ({ word: t(e), link: `/${e}` }))
-
   return (
     <S.Container>
-      <S.Header>
+      <S.Title>
         <S.Main>{t('homepage_title.main')}</S.Main>
         <S.Sub>{t('homepage_title.sub')}</S.Sub>
-      </S.Header>
-      <S.ListSection>
+      </S.Title>
+      <S.LinkGroup>
         <S.LinkButton>{t('hiragana')}</S.LinkButton>
         <S.LinkButton>{t('katakana')}</S.LinkButton>
         <S.LinkButton>{t('hiraganaDakuon')}</S.LinkButton>
         <S.LinkButton>{t('katakanaDakuon')}</S.LinkButton>
-      </S.ListSection>
+      </S.LinkGroup>
     </S.Container>
   )
 }

--- a/src/components/HomePageM/styles.js
+++ b/src/components/HomePageM/styles.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+export const S = {
+  Container: styled.div`
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  `,
+  Title: styled.header`
+    margin-top: 40px;
+    text-align: center;
+    user-select: none;
+  `,
+  Main: styled.p`
+    font-size: 4.5rem;
+  `,
+  Sub: styled.p`
+    font-size: 3.15rem;
+  `,
+  LinkGroup: styled.main`
+    width: 300px;
+    display: flex;
+    justify-content: space-between;
+    margin: auto;
+  `,
+  LinkButton: styled(Link)`
+    color: ${({ theme }) => theme.mercury};
+    writing-mode: vertical-lr;
+    text-decoration: none;
+    font-size: 1.75rem;
+    padding: 1rem;
+    border: 1px solid ${({ theme }) => theme.mercury};
+    border-radius: 15px;
+
+    &:nth-child(even) {
+      translate: 0 15px;
+    }
+
+    &:nth-child(odd) {
+      translate: 0 -15px;
+    }
+  `,
+}

--- a/src/components/Layout/styles.js
+++ b/src/components/Layout/styles.js
@@ -1,10 +1,39 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+const webBackground = css`
+  position: relative;
+  background-image: url('./templeWithFuji.jpg');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  backdrop-filter: blur(1px); //這行會影響背景顯示
+
+  &::before {
+    content: '';
+    width: 100%;
+    height: 100%;
+    display: block;
+    position: absolute;
+    z-index: -99;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: ${({ theme }) => theme.mercury + '77'};
+    backdrop-filter: blur(1px);
+  }
+`
 
 export const S = {
   Container: styled.div`
-    height: 100vh;
-    background-color: ${({ theme }) => theme.mercury + '77'};
-    backdrop-filter: blur(1px);
-    margin: auto;
+    width: 100%;
+    height: 100%;
+    /* TODO:
+         條件式渲染。
+         For Web show webBackground.
+         For mobile show pickled_blue_wood.
+    */
+    /* ${webBackground} */
+    background-color: ${({ theme }) => theme.pickled_blue_wood};
   `,
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,5 @@
 import ErrorPage from '../components/ErrorPage'
-import HomePage from '../components/HomePage'
+// import HomePage from '../components/HomePage'
+import HomePageM from '../components/HomePageM'
 
-export { ErrorPage, HomePage }
+export { ErrorPage, HomePageM as HomePage }

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -15,10 +15,6 @@ export const GlobalStyle = createGlobalStyle`
   :root {
     font-family: BIZUDPMincho, sans-serif;
     color: ${({ theme }) => theme.mercury};
-    background-image: url('./templeWithFuji.jpg');
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
     text-rendering: optimizeLegibility;
   }
 


### PR DESCRIPTION
## Related Issue :

This PR closes #32 

## Description :
新增一個組件用以顯示 mobile 的首頁，命名規則目前暫定在尾巴加上 M，在 pages 匯出時改回 HomePage 。
目的是打算之後邏輯都撰寫在 pages 中，並使用 React.lazy()，來選擇性渲染。
