### PR TITLE
fix: gp webview chart icon leaks before user has fail

### DIFF
--- a/src/components/GamePage/WebView/index.jsx
+++ b/src/components/GamePage/WebView/index.jsx
@@ -70,13 +70,15 @@ export default function WebView() {
               <S.HomeIcon onClick={onClick}>
                 <Home size={'100%'} />
               </S.HomeIcon>
-              <S.ChartIcon>
-                <ChartIcon
-                  color={mine_shaft}
-                  size={'60px'}
-                  position={{ top: 10, left: 10 }}
-                />
-              </S.ChartIcon>
+              {log.length ? (
+                <S.ChartIcon>
+                  <ChartIcon
+                    color={mine_shaft}
+                    size={'60px'}
+                    position={{ top: 10, left: 10 }}
+                  />
+                </S.ChartIcon>
+              ) : null}
               <S.QuestionSection>
                 <S.Subject>{current.word}</S.Subject>
               </S.QuestionSection>


### PR DESCRIPTION
## Description :
修正 gamepage webview 中的 chartIcon 在尚未有錯誤前就已經顯示出其位置。